### PR TITLE
Calibrate open in app

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Streamlined note searching and creation for [Bear](http://www.bear-writer.com/) using [Alfred](https://www.alfredapp.com/workflows/).
 
 ## Install
-Just [download](https://github.com/drgrib/alfred-bear/releases/download/1.1.2/Bear.alfredworkflow) the latest release and double-click _Bear.alfredworkflow_. Alfred will open the workflow and install it.
+Just [download](https://github.com/drgrib/alfred-bear/releases/download/1.1.3/Bear.alfredworkflow) the latest release and double-click _Bear.alfredworkflow_. Alfred will open the workflow and install it.
 
 ## Search
 `bs` or `bsearch`
@@ -43,7 +43,7 @@ All these terms can be typed in any order and they will work the same. For examp
 <img src="doc/TagAnyOrder.png" width="500">
 
 ### Search in Bear App
-You can search any query you type in the Bear app's main window by holding down the option key. If you've entered a tag, it will open the Bear main window to that tag for further browsing. 
+You can search any _query_ you type in the Bear app's main window by holding down the shift key. If you've entered a tag, it will open the Bear main window to that tag for further browsing. 
 
 <img src="doc/SearchQueryInBearApp.png" width="500">
 
@@ -54,6 +54,9 @@ The workflow will also autocomplete any of Bear's [Special Search keywords](http
 If you use these keywords and have no other search results, the workflow will automatically populate a "Search ... in Bear App" item without you needing to press option.
 
 <img src="doc/SearchSpecialInBearApp.png" width="500">
+
+### Open Note in Bear App
+Similarly, you can open any _note_ you select in the Bear app's main window by holding down the option key.
 
 ### Link Pasting
 

--- a/info.plist
+++ b/info.plist
@@ -27,7 +27,7 @@
 				<key>destinationuid</key>
 				<string>E2FCB7C2-A812-4419-9CD0-2E74282DF3FE</string>
 				<key>modifiers</key>
-				<integer>524288</integer>
+				<integer>131072</integer>
 				<key>modifiersubtext</key>
 				<string>Search Query in Bear App</string>
 				<key>vitoclose</key>
@@ -40,6 +40,16 @@
 				<integer>0</integer>
 				<key>modifiersubtext</key>
 				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>C09F10FC-E57F-47DA-9C55-84E9A68D2348</string>
+				<key>modifiers</key>
+				<integer>524288</integer>
+				<key>modifiersubtext</key>
+				<string>Open Note in Bear App</string>
 				<key>vitoclose</key>
 				<false/>
 			</dict>
@@ -109,7 +119,7 @@
 				<key>destinationuid</key>
 				<string>E2FCB7C2-A812-4419-9CD0-2E74282DF3FE</string>
 				<key>modifiers</key>
-				<integer>524288</integer>
+				<integer>131072</integer>
 				<key>modifiersubtext</key>
 				<string>Search Query in Bear App</string>
 				<key>vitoclose</key>
@@ -122,6 +132,16 @@
 				<integer>0</integer>
 				<key>modifiersubtext</key>
 				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>C09F10FC-E57F-47DA-9C55-84E9A68D2348</string>
+				<key>modifiers</key>
+				<integer>524288</integer>
+				<key>modifiersubtext</key>
+				<string>Open Note in Bear App</string>
 				<key>vitoclose</key>
 				<false/>
 			</dict>
@@ -142,7 +162,7 @@
 				<key>destinationuid</key>
 				<string>E2FCB7C2-A812-4419-9CD0-2E74282DF3FE</string>
 				<key>modifiers</key>
-				<integer>524288</integer>
+				<integer>131072</integer>
 				<key>modifiersubtext</key>
 				<string>Search Query in Bear App</string>
 				<key>vitoclose</key>
@@ -155,6 +175,16 @@
 				<integer>0</integer>
 				<key>modifiersubtext</key>
 				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>C09F10FC-E57F-47DA-9C55-84E9A68D2348</string>
+				<key>modifiers</key>
+				<integer>524288</integer>
+				<key>modifiersubtext</key>
+				<string>Open Note in Bear App</string>
 				<key>vitoclose</key>
 				<false/>
 			</dict>
@@ -175,7 +205,7 @@
 				<key>destinationuid</key>
 				<string>E2FCB7C2-A812-4419-9CD0-2E74282DF3FE</string>
 				<key>modifiers</key>
-				<integer>524288</integer>
+				<integer>131072</integer>
 				<key>modifiersubtext</key>
 				<string>Search Query in Bear App</string>
 				<key>vitoclose</key>
@@ -188,6 +218,16 @@
 				<integer>0</integer>
 				<key>modifiersubtext</key>
 				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>C09F10FC-E57F-47DA-9C55-84E9A68D2348</string>
+				<key>modifiers</key>
+				<integer>524288</integer>
+				<key>modifiersubtext</key>
+				<string>Open Note in Bear App</string>
 				<key>vitoclose</key>
 				<false/>
 			</dict>
@@ -252,11 +292,87 @@
 				<false/>
 			</dict>
 		</array>
+		<key>954F3962-1F0B-42A0-9C03-127E2690FA49</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>9E833A18-9A79-45A4-808C-D1891E6147CE</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>9E833A18-9A79-45A4-808C-D1891E6147CE</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>7936E4EC-9DD4-4C26-BFFD-9A300B4DC3D4</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
 		<key>A6BFE29A-BCCF-476F-8E07-A7C9CA647422</key>
 		<array>
 			<dict>
 				<key>destinationuid</key>
 				<string>2B3D525C-64BF-4146-92F4-A7012F05F6A2</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>B39E12A9-4E49-45C4-AE46-F56DEBD40B39</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>B0876656-9842-4ED2-A972-BD955ED9E68A</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>C09F10FC-E57F-47DA-9C55-84E9A68D2348</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>B39E12A9-4E49-45C4-AE46-F56DEBD40B39</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>sourceoutputuid</key>
+				<string>296ECF8E-6E4D-49DA-9B92-9883C5F5605A</string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>EFC3FC25-36AC-43BA-8054-038DDAD82831</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>sourceoutputuid</key>
+				<string>FDEE12A9-8486-48CB-B48E-6893D573BBD7</string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>954F3962-1F0B-42A0-9C03-127E2690FA49</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -303,6 +419,18 @@
 		</array>
 		<key>E2FCB7C2-A812-4419-9CD0-2E74282DF3FE</key>
 		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>B39E12A9-4E49-45C4-AE46-F56DEBD40B39</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>sourceoutputuid</key>
+				<string>296ECF8E-6E4D-49DA-9B92-9883C5F5605A</string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
 			<dict>
 				<key>destinationuid</key>
 				<string>0344727C-3BE1-4BC7-887A-82BECFC34B13</string>
@@ -487,6 +615,29 @@
 		<dict>
 			<key>config</key>
 			<dict>
+				<key>concurrently</key>
+				<false/>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>script</key>
+				<string>open "bear://x-callback-url/create?{query}&amp;show_window=yes&amp;new_window=no&amp;edit=yes"</string>
+				<key>scriptargtype</key>
+				<integer>0</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>type</key>
+				<integer>0</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.script</string>
+			<key>uid</key>
+			<string>B0876656-9842-4ED2-A972-BD955ED9E68A</string>
+			<key>version</key>
+			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
 				<key>matchmode</key>
 				<integer>1</integer>
 				<key>matchstring</key>
@@ -597,6 +748,27 @@
 			<string>E2FCB7C2-A812-4419-9CD0-2E74282DF3FE</string>
 			<key>version</key>
 			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>matchmode</key>
+				<integer>1</integer>
+				<key>matchstring</key>
+				<string>&amp;text=.+</string>
+				<key>regexcaseinsensitive</key>
+				<false/>
+				<key>regexmultiline</key>
+				<false/>
+				<key>replacestring</key>
+				<string></string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.utility.replace</string>
+			<key>uid</key>
+			<string>B39E12A9-4E49-45C4-AE46-F56DEBD40B39</string>
+			<key>version</key>
+			<integer>2</integer>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -738,6 +910,50 @@
 		<dict>
 			<key>config</key>
 			<dict>
+				<key>conditions</key>
+				<array>
+					<dict>
+						<key>inputstring</key>
+						<string></string>
+						<key>matchcasesensitive</key>
+						<false/>
+						<key>matchmode</key>
+						<integer>4</integer>
+						<key>matchstring</key>
+						<string>^(title=|tags=|text=)</string>
+						<key>outputlabel</key>
+						<string>CreateItem</string>
+						<key>uid</key>
+						<string>296ECF8E-6E4D-49DA-9B92-9883C5F5605A</string>
+					</dict>
+					<dict>
+						<key>inputstring</key>
+						<string></string>
+						<key>matchcasesensitive</key>
+						<false/>
+						<key>matchmode</key>
+						<integer>4</integer>
+						<key>matchstring</key>
+						<string>^(term=|tag=)|^$</string>
+						<key>outputlabel</key>
+						<string>AppSearchItem</string>
+						<key>uid</key>
+						<string>FDEE12A9-8486-48CB-B48E-6893D573BBD7</string>
+					</dict>
+				</array>
+				<key>elselabel</key>
+				<string>NoteID|searchCallback</string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.utility.conditional</string>
+			<key>uid</key>
+			<string>C09F10FC-E57F-47DA-9C55-84E9A68D2348</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
 				<key>concurrently</key>
 				<false/>
 				<key>escaping</key>
@@ -778,6 +994,94 @@
 			<string>alfred.workflow.action.script</string>
 			<key>uid</key>
 			<string>A6BFE29A-BCCF-476F-8E07-A7C9CA647422</string>
+			<key>version</key>
+			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>matchmode</key>
+				<integer>1</integer>
+				<key>matchstring</key>
+				<string>([^\|]+)\|([^\|]*)</string>
+				<key>regexcaseinsensitive</key>
+				<false/>
+				<key>regexmultiline</key>
+				<false/>
+				<key>replacestring</key>
+				<string>$1</string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.utility.replace</string>
+			<key>uid</key>
+			<string>EE68D5DB-1C41-45BB-94EF-267F95F56024</string>
+			<key>version</key>
+			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>concurrently</key>
+				<false/>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>script</key>
+				<string>open "bear://x-callback-url/open-note?id={query}&amp;show_window=yes&amp;new_window=no&amp;edit=yes"</string>
+				<key>scriptargtype</key>
+				<integer>0</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>type</key>
+				<integer>0</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.script</string>
+			<key>uid</key>
+			<string>9E833A18-9A79-45A4-808C-D1891E6147CE</string>
+			<key>version</key>
+			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>concurrently</key>
+				<false/>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>script</key>
+				<string>cmd/setcursor/setcursor</string>
+				<key>scriptargtype</key>
+				<integer>1</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>type</key>
+				<integer>0</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.script</string>
+			<key>uid</key>
+			<string>7936E4EC-9DD4-4C26-BFFD-9A300B4DC3D4</string>
+			<key>version</key>
+			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>matchmode</key>
+				<integer>1</integer>
+				<key>matchstring</key>
+				<string>([^\|]+)\|([^\|]*)</string>
+				<key>regexcaseinsensitive</key>
+				<false/>
+				<key>regexmultiline</key>
+				<false/>
+				<key>replacestring</key>
+				<string>$1</string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.utility.replace</string>
+			<key>uid</key>
+			<string>954F3962-1F0B-42A0-9C03-127E2690FA49</string>
 			<key>version</key>
 			<integer>2</integer>
 		</dict>
@@ -829,27 +1133,6 @@
 			<string>11295A3D-C960-41A3-9670-DFCBDF58C9D9</string>
 			<key>version</key>
 			<integer>3</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>matchmode</key>
-				<integer>1</integer>
-				<key>matchstring</key>
-				<string>([^\|]+)\|([^\|]*)</string>
-				<key>regexcaseinsensitive</key>
-				<false/>
-				<key>regexmultiline</key>
-				<false/>
-				<key>replacestring</key>
-				<string>$1</string>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.utility.replace</string>
-			<key>uid</key>
-			<string>EE68D5DB-1C41-45BB-94EF-267F95F56024</string>
-			<key>version</key>
-			<integer>2</integer>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -1035,21 +1318,21 @@
 			<key>xpos</key>
 			<integer>170</integer>
 			<key>ypos</key>
-			<integer>640</integer>
+			<integer>880</integer>
 		</dict>
 		<key>1197E934-E010-48A8-AF8E-CF0CF301C261</key>
 		<dict>
 			<key>xpos</key>
 			<integer>1105</integer>
 			<key>ypos</key>
-			<integer>830</integer>
+			<integer>1070</integer>
 		</dict>
 		<key>1E89EC6B-5E60-4AEE-800A-55A1E91B9182</key>
 		<dict>
 			<key>note</key>
 			<string>Create Note</string>
 			<key>xpos</key>
-			<integer>1350</integer>
+			<integer>1380</integer>
 			<key>ypos</key>
 			<integer>35</integer>
 		</dict>
@@ -1060,14 +1343,14 @@
 			<key>xpos</key>
 			<integer>1350</integer>
 			<key>ypos</key>
-			<integer>800</integer>
+			<integer>1040</integer>
 		</dict>
 		<key>2B3D525C-64BF-4146-92F4-A7012F05F6A2</key>
 		<dict>
 			<key>note</key>
 			<string>Set Cursor</string>
 			<key>xpos</key>
-			<integer>1350</integer>
+			<integer>1380</integer>
 			<key>ypos</key>
 			<integer>635</integer>
 		</dict>
@@ -1083,14 +1366,14 @@
 			<key>xpos</key>
 			<integer>10</integer>
 			<key>ypos</key>
-			<integer>775</integer>
+			<integer>1015</integer>
 		</dict>
 		<key>4D5617AA-ADE7-45B5-9C05-DA6C69781662</key>
 		<dict>
 			<key>xpos</key>
 			<integer>170</integer>
 			<key>ypos</key>
-			<integer>775</integer>
+			<integer>1015</integer>
 		</dict>
 		<key>59A4C675-2898-4D74-AA9C-C3F3E4A96A0A</key>
 		<dict>
@@ -1113,14 +1396,41 @@
 			<key>xpos</key>
 			<integer>1195</integer>
 			<key>ypos</key>
-			<integer>800</integer>
+			<integer>1040</integer>
 		</dict>
 		<key>6CEE5F7C-4415-417F-A095-4CE906185A93</key>
 		<dict>
+			<key>note</key>
+			<string>Open Note in New Window</string>
 			<key>xpos</key>
 			<integer>810</integer>
 			<key>ypos</key>
 			<integer>455</integer>
+		</dict>
+		<key>7936E4EC-9DD4-4C26-BFFD-9A300B4DC3D4</key>
+		<dict>
+			<key>note</key>
+			<string>Set Cursor</string>
+			<key>xpos</key>
+			<integer>1380</integer>
+			<key>ypos</key>
+			<integer>805</integer>
+		</dict>
+		<key>954F3962-1F0B-42A0-9C03-127E2690FA49</key>
+		<dict>
+			<key>xpos</key>
+			<integer>1105</integer>
+			<key>ypos</key>
+			<integer>835</integer>
+		</dict>
+		<key>9E833A18-9A79-45A4-808C-D1891E6147CE</key>
+		<dict>
+			<key>note</key>
+			<string>Open Note by ID in App</string>
+			<key>xpos</key>
+			<integer>1190</integer>
+			<key>ypos</key>
+			<integer>805</integer>
 		</dict>
 		<key>A6BFE29A-BCCF-476F-8E07-A7C9CA647422</key>
 		<dict>
@@ -1131,6 +1441,31 @@
 			<key>ypos</key>
 			<integer>635</integer>
 		</dict>
+		<key>B0876656-9842-4ED2-A972-BD955ED9E68A</key>
+		<dict>
+			<key>note</key>
+			<string>Create Note in App</string>
+			<key>xpos</key>
+			<integer>1380</integer>
+			<key>ypos</key>
+			<integer>185</integer>
+		</dict>
+		<key>B39E12A9-4E49-45C4-AE46-F56DEBD40B39</key>
+		<dict>
+			<key>xpos</key>
+			<integer>1195</integer>
+			<key>ypos</key>
+			<integer>320</integer>
+		</dict>
+		<key>C09F10FC-E57F-47DA-9C55-84E9A68D2348</key>
+		<dict>
+			<key>note</key>
+			<string>Open Note in Bear App</string>
+			<key>xpos</key>
+			<integer>810</integer>
+			<key>ypos</key>
+			<integer>610</integer>
+		</dict>
 		<key>C3AB4283-78DC-43E8-A8E5-BAB521E3E48D</key>
 		<dict>
 			<key>xpos</key>
@@ -1140,13 +1475,17 @@
 		</dict>
 		<key>D3FAABE3-B891-4CF6-BD99-89994FAC5A36</key>
 		<dict>
+			<key>note</key>
+			<string>Paste Link to Note</string>
 			<key>xpos</key>
 			<integer>810</integer>
 			<key>ypos</key>
-			<integer>775</integer>
+			<integer>1015</integer>
 		</dict>
 		<key>E2FCB7C2-A812-4419-9CD0-2E74282DF3FE</key>
 		<dict>
+			<key>note</key>
+			<string>Search Query in Bear App</string>
 			<key>xpos</key>
 			<integer>810</integer>
 			<key>ypos</key>
@@ -1164,7 +1503,7 @@
 			<key>note</key>
 			<string>Search in App</string>
 			<key>xpos</key>
-			<integer>1350</integer>
+			<integer>1380</integer>
 			<key>ypos</key>
 			<integer>450</integer>
 		</dict>


### PR DESCRIPTION
Calibrates opening queries and notes in the main Bear app. Queries will now be opened using *shift* instead of option. Notes can be opened using option. The reasoning being that if you accidentally continue to hold shift while selecting to open a note in the main app, it will select the entire contents of the note, possibly leading to accidental deletion of content. Opening queries introduces no such danger, so shift will be used to open them.