### PR TITLE
Proper lowercase for SQLite3

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/mattn/go-sqlite3"
 	_ "github.com/mattn/go-sqlite3"
 )
 
@@ -46,11 +47,11 @@ WHERE
 	note.ZARCHIVED=0
 	AND note.ZTRASHED=0
 	AND (
-		lower(note.ZTITLE) LIKE lower('%%%s%%') OR
-		lower(note.ZTEXT) LIKE lower('%%%s%%')
+		utflower(note.ZTITLE) LIKE utflower('%%%s%%') OR
+		utflower(note.ZTEXT) LIKE utflower('%%%s%%')
 	)
 GROUP BY note.ZUNIQUEIDENTIFIER
-ORDER BY case when lower(note.ZTITLE) LIKE lower('%%%s%%') then 0 else 1 end, note.ZMODIFICATIONDATE DESC
+ORDER BY case when utflower(note.ZTITLE) LIKE utflower('%%%s%%') then 0 else 1 end, note.ZMODIFICATIONDATE DESC
 LIMIT 400
 `
 
@@ -73,14 +74,14 @@ WHERE note.ZUNIQUEIDENTIFIER IN (
 		AND note.ZTRASHED=0
 		AND (%s)
 		AND (
-			lower(note.ZTITLE) LIKE lower('%%%s%%') OR
-			lower(note.ZTEXT) LIKE lower('%%%s%%')
+			utflower(note.ZTITLE) LIKE utflower('%%%s%%') OR
+			utflower(note.ZTEXT) LIKE utflower('%%%s%%')
 		)
 	GROUP BY note.ZUNIQUEIDENTIFIER
 	HAVING COUNT(*) >= %d
 )
 GROUP BY note.ZUNIQUEIDENTIFIER
-ORDER BY case when lower(note.ZTITLE) LIKE lower('%%%s%%') then 0 else 1 end, note.ZMODIFICATIONDATE DESC
+ORDER BY case when utflower(note.ZTITLE) LIKE utflower('%%%s%%') then 0 else 1 end, note.ZMODIFICATIONDATE DESC
 LIMIT 400
 `
 
@@ -94,7 +95,7 @@ FROM
 WHERE
 	n.ZARCHIVED=0
 	AND n.ZTRASHED=0
-	AND lower(t.ZTITLE) LIKE lower('%%%s%%')
+	AND utflower(t.ZTITLE) LIKE utflower('%%%s%%')
 ORDER BY
 	t.ZMODIFICATIONDATE DESC
 LIMIT 25
@@ -131,9 +132,19 @@ type LiteDB struct {
 }
 
 func NewLiteDB(path string) (LiteDB, error) {
-	db, err := sql.Open("sqlite3", path)
+	sql.Register("sqlite3_custom", &sqlite3.SQLiteDriver{
+		ConnectHook: func(conn *sqlite3.SQLiteConn) error {
+			return conn.RegisterFunc("utflower", utfLower, true)
+		},
+	})
+
+	db, err := sql.Open("sqlite3_custom", path)
 	litedb := LiteDB{db}
 	return litedb, err
+}
+
+func utfLower(s string) string {
+	return strings.ToLower(s)
 }
 
 func NewBearDB() (LiteDB, error) {
@@ -212,7 +223,7 @@ func (litedb LiteDB) queryNotesByTextAndTagConjunction(text, tagConjunction stri
 func (litedb LiteDB) QueryNotesByTextAndTags(text string, tags []string) ([]Note, error) {
 	tagConditions := []string{}
 	for _, t := range tags {
-		c := fmt.Sprintf("lower(tag.ZTITLE) = lower('%s')", t[1:])
+		c := fmt.Sprintf("utflower(tag.ZTITLE) = utflower('%s')", t[1:])
 		tagConditions = append(tagConditions, c)
 	}
 	tagConjunction := strings.Join(tagConditions, " OR ")

--- a/db/db.go
+++ b/db/db.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/mattn/go-sqlite3"
-	_ "github.com/mattn/go-sqlite3"
 )
 
 const (


### PR DESCRIPTION
SQLite3 lowercase and uppercase only ASCII. It ignores other charsets.

Bear knows how to search that:
<img width="683" alt="Screenshot 2020-08-27 at 17 05 39" src="https://user-images.githubusercontent.com/12697803/91453337-43dd6300-e888-11ea-9670-6f479ea4a7e6.png">

`bs` this note in recent, but it can't find it via word search:
<img width="729" alt="Screenshot 2020-08-27 at 17 05 47" src="https://user-images.githubusercontent.com/12697803/91453483-75562e80-e888-11ea-80d1-86b6dfe0987d.png">

<img width="729" alt="Screenshot 2020-08-27 at 17 05 55" src="https://user-images.githubusercontent.com/12697803/91453503-7d15d300-e888-11ea-98a5-d7a62998b18a.png">

The PR addresses the issue leveraging the Golang lowercase, making it work:
<img width="729" alt="Screenshot 2020-08-27 at 17 07 27" src="https://user-images.githubusercontent.com/12697803/91453615-a46ca000-e888-11ea-91cb-75c54fbc3169.png">
