### PR TITLE
Build with ICU

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,5 @@ require (
 	github.com/drgrib/alfred v0.0.0-20180713231015-cbcb1a4b1a30
 	github.com/drgrib/mac v0.0.0-20200321221020-4f366006daac
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
-	golang.org/x/text v0.3.2
+	golang.org/x/text v0.3.3
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,6 @@ github.com/drgrib/mac v0.0.0-20200321221020-4f366006daac h1:dbnAsr/ngd8DSzd3x/2C
 github.com/drgrib/mac v0.0.0-20200321221020-4f366006daac/go.mod h1:UaS3hPRZNCmKPJ1c9eKlIaehAOpSpBDLEsJTP/U6BSs=
 github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJKjyR5WD3HYQSd+U=
 github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
-golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
-golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
The suggested solution for using `lower()` on unicode characters found in the SQLite documentation is to [install the ICU extension](https://www.sqlitetutorial.net/sqlite-functions/sqlite-lower/#:~:text=The%20SQLite%20lower()%20function,ICU%20extension%20of%20this%20function.
). I've followed the [install](https://github.com/mattn/go-sqlite3#mac-osx) and [build](https://github.com/mattn/go-sqlite3#usage) instructions for using ICU with `go-sqlite3`.

This ICU build version successfully searches for lowercase Cyrillic letters with uppercase.

![image](https://user-images.githubusercontent.com/3879367/91508698-16df7f00-e88d-11ea-9c3a-adf51ab74eb1.png)

I cannot, however get it to search for uppercase using lowercase. @kudrykv if you can provide test strings or suggestions, I can test further.
