### PR TITLE
Test `ParseQuery`

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -3,6 +3,7 @@ package core
 import (
 	"fmt"
 	"net/url"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -90,22 +91,26 @@ func (query Query) String() string {
 	return strings.Join(query.Tokens, " ")
 }
 
+var spaces = regexp.MustCompile(`\s+`)
+
 func ParseQuery(arg string) Query {
-	query := Query{}
-	query.Tokens = strings.Split(norm.NFC.String(arg), " ")
-	query.Tags = []string{}
-	words := []string{}
+	query := Query{Tokens: spaces.Split(norm.NFC.String(arg), -1)}
+
+	query.Tags = make([]string, 0, len(query.Tokens))
+	words := make([]string, 0, len(query.Tokens))
+
 	for _, e := range query.Tokens {
 		switch {
-		case e == "":
 		case strings.HasPrefix(e, "#"):
 			query.Tags = append(query.Tags, e)
 		default:
 			words = append(words, e)
 		}
 	}
+
 	query.LastToken = query.Tokens[len(query.Tokens)-1]
 	query.WordString = strings.Join(words, " ")
+
 	return query
 }
 

--- a/core/core.go
+++ b/core/core.go
@@ -91,7 +91,7 @@ func (query Query) String() string {
 	return strings.Join(query.Tokens, " ")
 }
 
-var spaces = regexp.MustCompile(`\s+`)
+var spaces = regexp.MustCompile(`\s+`) //nolint:gochecknoglobals
 
 func ParseQuery(arg string) Query {
 	query := Query{Tokens: spaces.Split(norm.NFC.String(arg), -1)}

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -16,14 +16,14 @@ func TestParseQuery(t *testing.T) {
 		{
 			name:     "empty arg",
 			arg:      "",
-			expected: core.Query{},
+			expected: core.Query{Tokens: []string{""}, Tags: []string{}},
 		},
 		{
 			name: "single word",
 			arg:  "hello",
 			expected: core.Query{
 				Tokens:     []string{"hello"},
-				Tags:       nil,
+				Tags:       []string{},
 				LastToken:  "hello",
 				WordString: "hello",
 			},
@@ -33,7 +33,7 @@ func TestParseQuery(t *testing.T) {
 			arg:  "hello world",
 			expected: core.Query{
 				Tokens:     []string{"hello", "world"},
-				Tags:       nil,
+				Tags:       []string{},
 				LastToken:  "world",
 				WordString: "hello world",
 			},
@@ -43,7 +43,7 @@ func TestParseQuery(t *testing.T) {
 			arg:  "hello  \t world",
 			expected: core.Query{
 				Tokens:     []string{"hello", "world"},
-				Tags:       nil,
+				Tags:       []string{},
 				LastToken:  "world",
 				WordString: "hello world",
 			},
@@ -53,9 +53,9 @@ func TestParseQuery(t *testing.T) {
 			arg:  "hello #inbox stuff",
 			expected: core.Query{
 				Tokens:     []string{"hello", "#inbox", "stuff"},
-				Tags:       []string{"inbox"},
+				Tags:       []string{"#inbox"},
 				LastToken:  "stuff",
-				WordString: "hello #inbox stuff",
+				WordString: "hello stuff",
 			},
 		},
 		{
@@ -63,9 +63,19 @@ func TestParseQuery(t *testing.T) {
 			arg:  "hello #inbox",
 			expected: core.Query{
 				Tokens:     []string{"hello", "#inbox"},
-				Tags:       []string{"inbox"},
+				Tags:       []string{"#inbox"},
 				LastToken:  "#inbox",
-				WordString: "hello #inbox",
+				WordString: "hello",
+			},
+		},
+		{
+			name: "multiword tag",
+			arg:  "oh boy #hello tag#",
+			expected: core.Query{
+				Tokens:     []string{"oh", "boy", "#hello tag#"},
+				Tags:       []string{"#hello tag#"},
+				LastToken:  "#hello tag#",
+				WordString: "oh boy #hello tag#",
 			},
 		},
 	}
@@ -73,7 +83,9 @@ func TestParseQuery(t *testing.T) {
 	for _, test := range tests {
 		// nolint: scopelint
 		t.Run(test.name, func(t *testing.T) {
-			So(core.ParseQuery(test.arg), ShouldResemble, test.expected)
+			if ok, msg := So(core.ParseQuery(test.arg), ShouldResemble, test.expected); !ok {
+				t.Error(msg)
+			}
 		})
 	}
 }

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -39,7 +39,7 @@ func TestParseQuery(t *testing.T) {
 			},
 		},
 		{
-			name: "two words with bad spacing",
+			name: "multiple words with bad spacing",
 			arg:  "hello  \t world",
 			expected: core.Query{
 				Tokens:     []string{"hello", "world"},
@@ -68,16 +68,17 @@ func TestParseQuery(t *testing.T) {
 				WordString: "hello",
 			},
 		},
-		{
-			name: "multiword tag",
-			arg:  "oh boy #hello tag#",
-			expected: core.Query{
-				Tokens:     []string{"oh", "boy", "#hello tag#"},
-				Tags:       []string{"#hello tag#"},
-				LastToken:  "#hello tag#",
-				WordString: "oh boy #hello tag#",
-			},
-		},
+		// this would be nice to have in future
+		//{
+		//	name: "multiword tag",
+		//	arg:  "oh boy #hello tag#",
+		//	expected: core.Query{
+		//		Tokens:     []string{"oh", "boy", "#hello tag#"},
+		//		Tags:       []string{"#hello tag#"},
+		//		LastToken:  "#hello tag#",
+		//		WordString: "oh boy #hello tag#",
+		//	},
+		//},
 	}
 
 	for _, test := range tests {

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -1,0 +1,79 @@
+package core_test
+
+import (
+	"testing"
+
+	"github.com/drgrib/alfred-bear/core"
+	. "github.com/smartystreets/assertions"
+)
+
+func TestParseQuery(t *testing.T) {
+	tests := []struct {
+		name     string
+		arg      string
+		expected core.Query
+	}{
+		{
+			name:     "empty arg",
+			arg:      "",
+			expected: core.Query{},
+		},
+		{
+			name: "single word",
+			arg:  "hello",
+			expected: core.Query{
+				Tokens:     []string{"hello"},
+				Tags:       nil,
+				LastToken:  "hello",
+				WordString: "hello",
+			},
+		},
+		{
+			name: "two words",
+			arg:  "hello world",
+			expected: core.Query{
+				Tokens:     []string{"hello", "world"},
+				Tags:       nil,
+				LastToken:  "world",
+				WordString: "hello world",
+			},
+		},
+		{
+			name: "two words with bad spacing",
+			arg:  "hello  \t world",
+			expected: core.Query{
+				Tokens:     []string{"hello", "world"},
+				Tags:       nil,
+				LastToken:  "world",
+				WordString: "hello world",
+			},
+		},
+		{
+			name: "argument contains tag",
+			arg:  "hello #inbox stuff",
+			expected: core.Query{
+				Tokens:     []string{"hello", "#inbox", "stuff"},
+				Tags:       []string{"inbox"},
+				LastToken:  "stuff",
+				WordString: "hello #inbox stuff",
+			},
+		},
+		{
+			name: "tag is the last token",
+			arg:  "hello #inbox",
+			expected: core.Query{
+				Tokens:     []string{"hello", "#inbox"},
+				Tags:       []string{"inbox"},
+				LastToken:  "#inbox",
+				WordString: "hello #inbox",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		// nolint: scopelint
+		t.Run(test.name, func(t *testing.T) {
+			So(core.ParseQuery(test.arg), ShouldResemble, test.expected)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,6 @@ require (
 	github.com/drgrib/mac v0.0.0-20200321221020-4f366006daac
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/pkg/errors v0.9.1
+	github.com/smartystreets/assertions v1.1.1
 	golang.org/x/text v0.3.2
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJK
 github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/smartystreets/assertions v1.1.1 h1:T/YLemO5Yp7KPzS+lVtu+WsHn8yoSwTfItdAd1r3cck=
+github.com/smartystreets/assertions v1.1.1/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
Starting small.

The PR adds tests to `ParseQuery` function. It also changes the way arg is split. Instead of single space split, it uses regex to split by variable spaces between words.