### PR TITLE
Default to wiki-link for backlink support

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,6 +12,7 @@
                 "go build toc",
                 "go build create",
                 "go build setcursor",
+                "go build wiki-link",
             ],
             "group": "build"
         },
@@ -87,6 +88,19 @@
                 "cwd": "${workspaceFolder}/cmd/setcursor"
             },
             "command": "rm -f setcursor; go build",
+            "presentation": {
+                "focus": true,
+            },
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "go build wiki-link",
+            "type": "shell",
+            "options": {
+                "cwd": "${workspaceFolder}/cmd/wiki-link"
+            },
+            "command": "rm -f wiki-link; go build",
             "presentation": {
                 "focus": true,
             },

--- a/cmd/wiki-link/main.go
+++ b/cmd/wiki-link/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"golang.org/x/text/unicode/norm"
+
+	"github.com/drgrib/alfred-bear/db"
+)
+
+func main() {
+	noteID := norm.NFC.String(os.Args[1])
+
+	litedb, err := db.NewBearDB()
+	if err != nil {
+		panic(err)
+	}
+
+	rows, err := litedb.Query(fmt.Sprintf(db.NOTE_TITLE_BY_ID, noteID))
+	if err != nil {
+		panic(err)
+	}
+	title := rows[0][db.TitleKey]
+	title = strings.ReplaceAll(title, "[", `\[`)
+	title = strings.ReplaceAll(title, "]", `\]`)
+	title = strings.ReplaceAll(title, "/", `\/`)
+	link := fmt.Sprintf("[[%s]]", title)
+
+	fmt.Print(link)
+}

--- a/info.plist
+++ b/info.plist
@@ -8,6 +8,19 @@
 	<string>Tools</string>
 	<key>connections</key>
 	<dict>
+		<key>00E5D1C8-D8AE-43EF-9E0D-92F25F59FE62</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>E92972B8-8164-49C7-BBA8-064C3B42EC29</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
 		<key>0344727C-3BE1-4BC7-887A-82BECFC34B13</key>
 		<array>
 			<dict>
@@ -55,9 +68,19 @@
 			</dict>
 			<dict>
 				<key>destinationuid</key>
-				<string>D3FAABE3-B891-4CF6-BD99-89994FAC5A36</string>
+				<string>905FC2FC-858B-476F-9DBA-D143CD446DFC</string>
 				<key>modifiers</key>
 				<integer>131072</integer>
+				<key>modifiersubtext</key>
+				<string>Paste Wiki-Link to Note</string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>D3FAABE3-B891-4CF6-BD99-89994FAC5A36</string>
+				<key>modifiers</key>
+				<integer>1179648</integer>
 				<key>modifiersubtext</key>
 				<string>Paste Link to Note</string>
 				<key>vitoclose</key>
@@ -67,7 +90,7 @@
 				<key>destinationuid</key>
 				<string>1E42F790-0DFA-452B-A0F5-5FEA0ACA22E5</string>
 				<key>modifiers</key>
-				<integer>1179648</integer>
+				<integer>1572864</integer>
 				<key>modifiersubtext</key>
 				<string>Paste Table of Contents</string>
 				<key>vitoclose</key>
@@ -92,6 +115,19 @@
 			<dict>
 				<key>destinationuid</key>
 				<string>A17A4C24-15DE-4D34-9704-76E6483B412C</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>23C93BAC-491B-42FF-8E63-F529CFCBCCD7</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>00E5D1C8-D8AE-43EF-9E0D-92F25F59FE62</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -170,9 +206,19 @@
 			</dict>
 			<dict>
 				<key>destinationuid</key>
-				<string>D3FAABE3-B891-4CF6-BD99-89994FAC5A36</string>
+				<string>905FC2FC-858B-476F-9DBA-D143CD446DFC</string>
 				<key>modifiers</key>
 				<integer>131072</integer>
+				<key>modifiersubtext</key>
+				<string>Paste Wiki-Link to Note</string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>D3FAABE3-B891-4CF6-BD99-89994FAC5A36</string>
+				<key>modifiers</key>
+				<integer>1179648</integer>
 				<key>modifiersubtext</key>
 				<string>Paste Link to Note</string>
 				<key>vitoclose</key>
@@ -182,7 +228,7 @@
 				<key>destinationuid</key>
 				<string>1E42F790-0DFA-452B-A0F5-5FEA0ACA22E5</string>
 				<key>modifiers</key>
-				<integer>1179648</integer>
+				<integer>1572864</integer>
 				<key>modifiersubtext</key>
 				<string>Paste Table of Contents</string>
 				<key>vitoclose</key>
@@ -223,9 +269,19 @@
 			</dict>
 			<dict>
 				<key>destinationuid</key>
-				<string>D3FAABE3-B891-4CF6-BD99-89994FAC5A36</string>
+				<string>905FC2FC-858B-476F-9DBA-D143CD446DFC</string>
 				<key>modifiers</key>
 				<integer>131072</integer>
+				<key>modifiersubtext</key>
+				<string>Paste Wiki-Link to Note</string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>D3FAABE3-B891-4CF6-BD99-89994FAC5A36</string>
+				<key>modifiers</key>
+				<integer>1179648</integer>
 				<key>modifiersubtext</key>
 				<string>Paste Link to Note</string>
 				<key>vitoclose</key>
@@ -235,7 +291,7 @@
 				<key>destinationuid</key>
 				<string>1E42F790-0DFA-452B-A0F5-5FEA0ACA22E5</string>
 				<key>modifiers</key>
-				<integer>1179648</integer>
+				<integer>1572864</integer>
 				<key>modifiersubtext</key>
 				<string>Paste Table of Contents</string>
 				<key>vitoclose</key>
@@ -276,9 +332,19 @@
 			</dict>
 			<dict>
 				<key>destinationuid</key>
-				<string>D3FAABE3-B891-4CF6-BD99-89994FAC5A36</string>
+				<string>905FC2FC-858B-476F-9DBA-D143CD446DFC</string>
 				<key>modifiers</key>
 				<integer>131072</integer>
+				<key>modifiersubtext</key>
+				<string>Paste Wiki-Link to Note</string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>D3FAABE3-B891-4CF6-BD99-89994FAC5A36</string>
+				<key>modifiers</key>
+				<integer>1179648</integer>
 				<key>modifiersubtext</key>
 				<string>Paste Link to Note</string>
 				<key>vitoclose</key>
@@ -288,7 +354,7 @@
 				<key>destinationuid</key>
 				<string>1E42F790-0DFA-452B-A0F5-5FEA0ACA22E5</string>
 				<key>modifiers</key>
-				<integer>1179648</integer>
+				<integer>1572864</integer>
 				<key>modifiersubtext</key>
 				<string>Paste Table of Contents</string>
 				<key>vitoclose</key>
@@ -337,6 +403,19 @@
 			<dict>
 				<key>destinationuid</key>
 				<string>EE68D5DB-1C41-45BB-94EF-267F95F56024</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>905FC2FC-858B-476F-9DBA-D143CD446DFC</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>23C93BAC-491B-42FF-8E63-F529CFCBCCD7</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -559,6 +638,19 @@
 				<false/>
 			</dict>
 		</array>
+		<key>FED949AC-9EA3-45BB-90ED-8309D3BFB323</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>5D8E2482-13A9-4FCB-96CA-C66F35949E2A</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
 	</dict>
 	<key>createdby</key>
 	<string>drgrib</string>
@@ -639,6 +731,37 @@
 			<string>alfred.workflow.action.script</string>
 			<key>uid</key>
 			<string>1E89EC6B-5E60-4AEE-800A-55A1E91B9182</string>
+			<key>version</key>
+			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>action</key>
+				<integer>0</integer>
+				<key>argument</key>
+				<integer>0</integer>
+				<key>focusedappvariable</key>
+				<false/>
+				<key>focusedappvariablename</key>
+				<string></string>
+				<key>hotkey</key>
+				<integer>0</integer>
+				<key>hotmod</key>
+				<integer>0</integer>
+				<key>hotstring</key>
+				<string></string>
+				<key>leftcursor</key>
+				<false/>
+				<key>modsmode</key>
+				<integer>0</integer>
+				<key>relatedAppsMode</key>
+				<integer>0</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.trigger.hotkey</string>
+			<key>uid</key>
+			<string>FED949AC-9EA3-45BB-90ED-8309D3BFB323</string>
 			<key>version</key>
 			<integer>2</integer>
 		</dict>
@@ -1222,52 +1345,6 @@
 		<dict>
 			<key>config</key>
 			<dict>
-				<key>conditions</key>
-				<array>
-					<dict>
-						<key>inputstring</key>
-						<string></string>
-						<key>matchcasesensitive</key>
-						<false/>
-						<key>matchmode</key>
-						<integer>4</integer>
-						<key>matchstring</key>
-						<string>^(title=|tags=|text=)</string>
-						<key>outputlabel</key>
-						<string>CreateItem</string>
-						<key>uid</key>
-						<string>296ECF8E-6E4D-49DA-9B92-9883C5F5605A</string>
-					</dict>
-					<dict>
-						<key>inputstring</key>
-						<string></string>
-						<key>matchcasesensitive</key>
-						<false/>
-						<key>matchmode</key>
-						<integer>4</integer>
-						<key>matchstring</key>
-						<string>^(term=|tag=)|^$</string>
-						<key>outputlabel</key>
-						<string>AppSearchItem</string>
-						<key>uid</key>
-						<string>FDEE12A9-8486-48CB-B48E-6893D573BBD7</string>
-					</dict>
-				</array>
-				<key>elselabel</key>
-				<string>NoteID|searchCallback</string>
-				<key>hideelse</key>
-				<false/>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.utility.conditional</string>
-			<key>uid</key>
-			<string>D3FAABE3-B891-4CF6-BD99-89994FAC5A36</string>
-			<key>version</key>
-			<integer>1</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
 				<key>availableviaurlhandler</key>
 				<false/>
 				<key>triggerid</key>
@@ -1328,6 +1405,161 @@
 			<string>4D5617AA-ADE7-45B5-9C05-DA6C69781662</string>
 			<key>version</key>
 			<integer>3</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>conditions</key>
+				<array>
+					<dict>
+						<key>inputstring</key>
+						<string></string>
+						<key>matchcasesensitive</key>
+						<false/>
+						<key>matchmode</key>
+						<integer>4</integer>
+						<key>matchstring</key>
+						<string>^(title=|tags=|text=)</string>
+						<key>outputlabel</key>
+						<string>CreateItem</string>
+						<key>uid</key>
+						<string>296ECF8E-6E4D-49DA-9B92-9883C5F5605A</string>
+					</dict>
+					<dict>
+						<key>inputstring</key>
+						<string></string>
+						<key>matchcasesensitive</key>
+						<false/>
+						<key>matchmode</key>
+						<integer>4</integer>
+						<key>matchstring</key>
+						<string>^(term=|tag=)|^$</string>
+						<key>outputlabel</key>
+						<string>AppSearchItem</string>
+						<key>uid</key>
+						<string>FDEE12A9-8486-48CB-B48E-6893D573BBD7</string>
+					</dict>
+				</array>
+				<key>elselabel</key>
+				<string>NoteID|searchCallback</string>
+				<key>hideelse</key>
+				<false/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.utility.conditional</string>
+			<key>uid</key>
+			<string>905FC2FC-858B-476F-9DBA-D143CD446DFC</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>autopaste</key>
+				<true/>
+				<key>clipboardtext</key>
+				<string>{query}</string>
+				<key>ignoredynamicplaceholders</key>
+				<false/>
+				<key>transient</key>
+				<false/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.output.clipboard</string>
+			<key>uid</key>
+			<string>E92972B8-8164-49C7-BBA8-064C3B42EC29</string>
+			<key>version</key>
+			<integer>3</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>concurrently</key>
+				<false/>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>script</key>
+				<string>cmd/wiki-link/wiki-link "{query}"</string>
+				<key>scriptargtype</key>
+				<integer>0</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>type</key>
+				<integer>0</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.script</string>
+			<key>uid</key>
+			<string>00E5D1C8-D8AE-43EF-9E0D-92F25F59FE62</string>
+			<key>version</key>
+			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>matchmode</key>
+				<integer>1</integer>
+				<key>matchstring</key>
+				<string>([^\|]+)\|([^\|]*)</string>
+				<key>regexcaseinsensitive</key>
+				<false/>
+				<key>regexmultiline</key>
+				<false/>
+				<key>replacestring</key>
+				<string>$1</string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.utility.replace</string>
+			<key>uid</key>
+			<string>23C93BAC-491B-42FF-8E63-F529CFCBCCD7</string>
+			<key>version</key>
+			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>conditions</key>
+				<array>
+					<dict>
+						<key>inputstring</key>
+						<string></string>
+						<key>matchcasesensitive</key>
+						<false/>
+						<key>matchmode</key>
+						<integer>4</integer>
+						<key>matchstring</key>
+						<string>^(title=|tags=|text=)</string>
+						<key>outputlabel</key>
+						<string>CreateItem</string>
+						<key>uid</key>
+						<string>296ECF8E-6E4D-49DA-9B92-9883C5F5605A</string>
+					</dict>
+					<dict>
+						<key>inputstring</key>
+						<string></string>
+						<key>matchcasesensitive</key>
+						<false/>
+						<key>matchmode</key>
+						<integer>4</integer>
+						<key>matchstring</key>
+						<string>^(term=|tag=)|^$</string>
+						<key>outputlabel</key>
+						<string>AppSearchItem</string>
+						<key>uid</key>
+						<string>FDEE12A9-8486-48CB-B48E-6893D573BBD7</string>
+					</dict>
+				</array>
+				<key>elselabel</key>
+				<string>NoteID|searchCallback</string>
+				<key>hideelse</key>
+				<false/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.utility.conditional</string>
+			<key>uid</key>
+			<string>D3FAABE3-B891-4CF6-BD99-89994FAC5A36</string>
+			<key>version</key>
+			<integer>1</integer>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -1506,6 +1738,15 @@
 	<string></string>
 	<key>uidata</key>
 	<dict>
+		<key>00E5D1C8-D8AE-43EF-9E0D-92F25F59FE62</key>
+		<dict>
+			<key>note</key>
+			<string>Format Link</string>
+			<key>xpos</key>
+			<real>1180</real>
+			<key>ypos</key>
+			<real>1050</real>
+		</dict>
 		<key>0344727C-3BE1-4BC7-887A-82BECFC34B13</key>
 		<dict>
 			<key>xpos</key>
@@ -1523,18 +1764,18 @@
 		<key>1197E934-E010-48A8-AF8E-CF0CF301C261</key>
 		<dict>
 			<key>xpos</key>
-			<real>1105</real>
+			<real>1090</real>
 			<key>ypos</key>
-			<real>1070</real>
+			<real>1235</real>
 		</dict>
 		<key>1E42F790-0DFA-452B-A0F5-5FEA0ACA22E5</key>
 		<dict>
 			<key>note</key>
 			<string>Paste Link to Table of Contents</string>
 			<key>xpos</key>
-			<real>810</real>
+			<real>795</real>
 			<key>ypos</key>
-			<real>1185</real>
+			<real>1350</real>
 		</dict>
 		<key>1E89EC6B-5E60-4AEE-800A-55A1E91B9182</key>
 		<dict>
@@ -1545,14 +1786,21 @@
 			<key>ypos</key>
 			<real>35</real>
 		</dict>
+		<key>23C93BAC-491B-42FF-8E63-F529CFCBCCD7</key>
+		<dict>
+			<key>xpos</key>
+			<real>1090</real>
+			<key>ypos</key>
+			<real>1080</real>
+		</dict>
 		<key>27456FAE-DBC0-4A91-9753-517B00831DB3</key>
 		<dict>
 			<key>note</key>
 			<string>Paste Link</string>
 			<key>xpos</key>
-			<real>1350</real>
+			<real>1335</real>
 			<key>ypos</key>
-			<real>1040</real>
+			<real>1205</real>
 		</dict>
 		<key>2B3D525C-64BF-4146-92F4-A7012F05F6A2</key>
 		<dict>
@@ -1603,9 +1851,9 @@
 			<key>note</key>
 			<string>Format Link</string>
 			<key>xpos</key>
-			<real>1195</real>
+			<real>1180</real>
 			<key>ypos</key>
-			<real>1040</real>
+			<real>1205</real>
 		</dict>
 		<key>6CEE5F7C-4415-417F-A095-4CE906185A93</key>
 		<dict>
@@ -1624,6 +1872,15 @@
 			<real>1380</real>
 			<key>ypos</key>
 			<real>805</real>
+		</dict>
+		<key>905FC2FC-858B-476F-9DBA-D143CD446DFC</key>
+		<dict>
+			<key>note</key>
+			<string>Paste Wiki-Link to Note</string>
+			<key>xpos</key>
+			<real>795</real>
+			<key>ypos</key>
+			<real>1025</real>
 		</dict>
 		<key>954F3962-1F0B-42A0-9C03-127E2690FA49</key>
 		<dict>
@@ -1644,9 +1901,9 @@
 		<key>A17A4C24-15DE-4D34-9704-76E6483B412C</key>
 		<dict>
 			<key>xpos</key>
-			<real>1105</real>
+			<real>1090</real>
 			<key>ypos</key>
-			<real>1240</real>
+			<real>1405</real>
 		</dict>
 		<key>A6BFE29A-BCCF-476F-8E07-A7C9CA647422</key>
 		<dict>
@@ -1678,9 +1935,9 @@
 			<key>note</key>
 			<string>ToC</string>
 			<key>xpos</key>
-			<real>1195</real>
+			<real>1180</real>
 			<key>ypos</key>
-			<real>1210</real>
+			<real>1375</real>
 		</dict>
 		<key>C09F10FC-E57F-47DA-9C55-84E9A68D2348</key>
 		<dict>
@@ -1703,18 +1960,18 @@
 			<key>note</key>
 			<string>Paste Link to Note</string>
 			<key>xpos</key>
-			<real>810</real>
+			<real>795</real>
 			<key>ypos</key>
-			<real>1015</real>
+			<real>1180</real>
 		</dict>
 		<key>DA7313D4-6521-4C7B-B408-903CF0C760FB</key>
 		<dict>
 			<key>note</key>
 			<string>Paste Link</string>
 			<key>xpos</key>
-			<real>1350</real>
+			<real>1335</real>
 			<key>ypos</key>
-			<real>1210</real>
+			<real>1375</real>
 		</dict>
 		<key>E2FCB7C2-A812-4419-9CD0-2E74282DF3FE</key>
 		<dict>
@@ -1724,6 +1981,15 @@
 			<real>810</real>
 			<key>ypos</key>
 			<real>315</real>
+		</dict>
+		<key>E92972B8-8164-49C7-BBA8-064C3B42EC29</key>
+		<dict>
+			<key>note</key>
+			<string>Paste Link</string>
+			<key>xpos</key>
+			<real>1335</real>
+			<key>ypos</key>
+			<real>1050</real>
 		</dict>
 		<key>EE68D5DB-1C41-45BB-94EF-267F95F56024</key>
 		<dict>
@@ -1748,13 +2014,20 @@
 			<key>ypos</key>
 			<real>200</real>
 		</dict>
+		<key>FED949AC-9EA3-45BB-90ED-8309D3BFB323</key>
+		<dict>
+			<key>xpos</key>
+			<real>30</real>
+			<key>ypos</key>
+			<real>160</real>
+		</dict>
 	</dict>
 	<key>userconfigurationconfig</key>
 	<array/>
 	<key>variablesdontexport</key>
 	<array/>
 	<key>version</key>
-	<string>1.2</string>
+	<string>1.2.1</string>
 	<key>webaddress</key>
 	<string>https://github.com/drgrib/alfred-bear</string>
 </dict>


### PR DESCRIPTION
Adds wiki-link as default `shift` link to support new Bear backlinks in info tab.

An annoying caveat to this is that you must now `cmd`-click links to open them in a new window. @msageryd has made a feature request with Bear support to have "open links in new window" as a global Bear setting and they sound receptive to supporting it in future releases.

You can paste the previous default links with `shift-cmd`. Pasting ToC has been changed to `option-cmd` since it is less useful now with Bear 2's built-in ToC support.